### PR TITLE
Adjust spec/changes to ver. 0.163.0, fix bsc#1091988

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Apr 03 13:46:40 UTC 2018 - imanyugin@suse.com
+
+- Version 0.163.0
+- Fix bsc#1091988:SAPHanaSR-ScaleOut SAPHanaSR-monitor depends on package not existing in SLES
+- Fix bsc#1045603: Update man pages
+- Fix bsc#1045536: SAPHanaSR-ScaleOut missing update to use SLES python
+- Fix bsc#1086545: minor typos in package description and man pages
+
+-------------------------------------------------------------------
 Thu Jul 14 13:51:45 UTC 2016 - imanyugin@suse.com
 
 - Version 0.161.1

--- a/SAPHana/SAPHanaSR-ScaleOut.spec
+++ b/SAPHana/SAPHanaSR-ScaleOut.spec
@@ -20,7 +20,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.161.1
+Version:        0.163.0
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 Source0:        SAPHanaSR-ScaleOut-%{version}.tar.bz2
@@ -125,6 +125,7 @@ install -m 0444 srHook/global.ini %{buildroot}/usr/share/%{name}/samples
 %doc /usr/share/man/man7/ocf_suse_SAPHanaController.7.gz
 %doc /usr/share/man/man7/ocf_suse_SAPHanaTopology.7.gz
 %doc /usr/share/man/man7/SAPHanaSR-ScaleOut.7.gz
+%doc /usr/share/man/man7/SAPHanaSR-ScaleOut_basic_cluster.7.gz
 %doc /usr/share/man/man7/SAPHanaSR.py.7.gz
 %doc /usr/share/man/man8/SAPHanaSR-monitor.8.gz
 %doc /usr/share/man/man8/SAPHanaSR-showAttr.8.gz

--- a/SAPHana/bin/SAPHanaSR-monitor
+++ b/SAPHana/bin/SAPHanaSR-monitor
@@ -14,7 +14,6 @@ use strict;
 use Sys::Syslog;
 use Sys::Hostname;
 use File::Path;
-use Switch;
 use Getopt::Long;
 use lib '/usr/lib/SAPHanaSR-ScaleOut';
 use SAPHanaSRTools;

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -33,7 +33,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaControllerVersion="0.161.5"
+SAPHanaControllerVersion="0.163.0"
 #
 # Initialization:
 timeB=$(date '+%s')

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -25,7 +25,7 @@
 #
 #######################################################################
 # DONE PRIO 1: AFTER(!) SAP HANA SPS12 is available we could use hdbnsutil --sr_stateConfiguration
-SAPHanaTopologyVersion="0.161.4"
+SAPHanaTopologyVersion="0.163.0"
 #
 # Initialization:
 timeB=$(date '+%s')


### PR DESCRIPTION
- Version bump to 0.163.0
- Adjust .spec file and .changes to reflect the new version
- Adjust RAs to the same version string
- Fix bsc#1091988: SAPHanaSR-ScaleOut SAPHanaSR-monitor depends on package not existing in SLES