### PR TITLE
Initial lint infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get -t trusty-backports install shellcheck
+  - sudo apt-get -qq install libperl-critic-perl python-flake8
+script:
+  - pushd SAPHana
+  - make test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+
+# SUSE ScaleOut resource agent for SAP HANA
+
+[![Build Status](https://travis-ci.com/SUSE/SAPHanaSR-ScaleOut.svg?branch=master)](https://travis-ci.com/SUSE/SAPHanaSR-ScaleOut)
+
+## Introduction
+
+SAPHanaSR Scale-Out provides an automatic failover between SAP HANA nodes with configured System Replication for complex HANA Scale-Out configurations running in two different locations.
+
+This technology is included in SLES for SAP 12 SP2 or later.
+

--- a/SAPHana/.perlcriticrc
+++ b/SAPHana/.perlcriticrc
@@ -1,0 +1,10 @@
+[Perl::Critic::Policy::HashKeyQuotes]
+severity = 5
+
+[Perl::Critic::Policy::ConsistentQuoteLikeWords]
+severity = 5
+
+# this policy is considered harmful by the wider perl community
+[-Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef]
+
+[-Subroutines::ProhibitSubroutinePrototypes]

--- a/SAPHana/.perltidyrc
+++ b/SAPHana/.perltidyrc
@@ -1,0 +1,9 @@
+-l=120   # 120 characters per line
+-fbl     # don't change blank lines
+-nsfs    # no spaces before semicolons
+-baao    # space after operators
+-bbao    # space before operators
+-pt=2    # no spaces around ()
+-bt=2    # no spaces around []
+-sbt=2   # no spaces around {}
+-sct # stack closing tokens )}

--- a/SAPHana/Makefile
+++ b/SAPHana/Makefile
@@ -1,3 +1,4 @@
+PROVE_ARGS ?= -r -v
 FILE_LIST = crmconfig \
 			doc \
 			man \
@@ -53,3 +54,14 @@ commit: copy
 	@echo -e "\e[32mDone\e[0m"
 
 .phony: 	tarball
+
+.PHONY: checkstyle
+checkstyle:
+ifneq ($(CHECKSTYLE),0)
+	find . -type f -exec awk ' /^#!.*bash/{print FILENAME} {nextfile}' {} + | xargs shellcheck -s bash
+	find . -type f -exec awk ' /^#!.*perl/{print FILENAME} {nextfile}' {} + | xargs perlcritic --gentle
+	find . -name '*.py' | xargs flake8
+endif
+
+PHONY: test
+test: checkstyle


### PR DESCRIPTION
The bug https://bugzilla.suse.com/1091988 remind us that this codebase is still not up to the level of discipline where it should be for a SUSE product.

Two branches, with conflicting answers what purpose they serve, and submitted binaries that do not even run.

Was this preventable? Totally. A good tested and linted codebase will not fix all our problems, but when our problems *are* detected by tests or lints, then it means we are wasting time and risking human errors and oversights.

Running a basic perl linter on the code warns you about the usage of `Switch` in the code already!:

![screenshot from 2018-05-09 11-32-20](https://user-images.githubusercontent.com/15332/39808112-641a9d50-537e-11e8-998b-177ac0f9c7b7.png)

So, this PR implements basic lint infrastructure that most of modern codebases have. In addition, it adds a build badge in the README, so that from Github you will see immediately in the README if the code is green or not:

![screenshot from 2018-05-09 11-45-33](https://user-images.githubusercontent.com/15332/39808246-b60b01f4-537e-11e8-9425-2b67dfd9bd2b.png)
(of course this will be totally red at the beginning).

I setup 3 linters:

* [Perl::Critic](http://www.perlcritic.org/), for Perl
* [Shellcheck](https://www.shellcheck.net/), for Shell scripts
* [Flake8](https://pypi.org/project/flake8/), for Python

If our resource agents would be upstream, we would be covered with shell linting already. If our YaST code would be upstream in the YaST project, they also have a lint infrastructure that makes sure the code is up to the higher quality levels and conventions. Not being part of upstream does not mean we can have code without any convention or basic checking.

Right now there are hundred of "failures" in the code. I propose to introduce this and setup a concrete goal to reduce the number of violations over time and get to zero. We can do it all together, one line at a time. Next step would be to do something similar with SAPHanaSR (unless merging the codebases is something feasible, as I see lot of duplication), and also then the YaST pieces, should also be up to the standard of the upstream YaST modules.

//cc @krig @angelabriel @diegoakechi @ChrisKowalczyk @ayoub-belarbi 

