### PR TITLE
Replace POSIX::tolower calls to lc

### DIFF
--- a/SAPHana/bin/SAPHanaSR-showAttr
+++ b/SAPHana/bin/SAPHanaSR-showAttr
@@ -77,7 +77,7 @@ if ( 0 == @sids ) {
 
 foreach $sid (@sids) {
     ( $sid, $ino ) = split(":", $sid);
-    $sid=tolower("$sid");
+    $sid=lc("$sid");
     %Host=(); %HName=(); %Global=(); %GName=(); %Site=(); %SName=();
     get_hana_attributes($sid, \%Host, \%HName, \%Global, \%GName, \%Site,   \%SName);
     if ( keys(%Host) == 0 ) {

--- a/SAPHana/fh_test/fh_test_driver
+++ b/SAPHana/fh_test/fh_test_driver
@@ -95,7 +95,7 @@ sub get_node_status($)
            $result="online";
         } elsif ( /^Node\s+$node:\s+(\S+)/  ) {
            #printf("N: %s: %s\n", $_, $1);
-           $result=tolower($1);
+           $result=lc($1);
 
         }
     }
@@ -111,7 +111,7 @@ sub get_sid()
        # try to catch:  Inst Info : LNX - 42 - lv9041 - 740, patch 36, changelist 1444691
        chomp;
        if ( $_ =~ /:\s+([A-Z][A-Z0-9][A-Z0-9])\s+-/ ) {
-          $sid=tolower("$1");
+          $sid=lc("$1");
        }
     }
     close ListInstances;

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -140,13 +140,13 @@ sub get_sid_and_InstNr()
             my $foundINO=$2;
             if ( $foundSID ne "DAA" ) {
                 $noDAACount++;
-                $sid=tolower($foundSID);
+                $sid=lc($foundSID);
                 $Inr=$foundINO;
                 push @sid_ino, "$sid:$Inr";
             }
         }
 #       if ( $_ =~ /:\s+([A-Z][A-Z0-9][A-Z0-9])\s+-\s+([0-9][0-9])/ ) {
-#          $sid=tolower("$1");
+#          $sid=lc("$1");
 #          $Inr=$2;
     }
     close ListInstances;


### PR DESCRIPTION
POSIX::tolower was dropped in 5.26.0 (see changelog https://perldoc.perl.org/perl5260delta.html)
This references bsc#1091074