### PR TITLE
Version bump to 0.163.1

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jun 26 13:40:14 UTC 2018 - imanyugin@suse.com
+
+- Version 0.163.1
+
+-------------------------------------------------------------------
 Tue May 08 10:56:48 UTC 2018 - imanyugin@suse.com
 
 - Fix bsc#1092331: SAPHanaSR: SAPHanaSR-showAttr fails to open an archived cib file

--- a/SAPHana/SAPHanaSR-ScaleOut.spec
+++ b/SAPHana/SAPHanaSR-ScaleOut.spec
@@ -20,7 +20,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.163.0
+Version:        0.163.1
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 Source0:        SAPHanaSR-ScaleOut-%{version}.tar.bz2

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -33,7 +33,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaControllerVersion="0.163.0"
+SAPHanaControllerVersion="0.163.1"
 #
 # Initialization:
 timeB=$(date '+%s')

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -25,7 +25,7 @@
 #
 #######################################################################
 # DONE PRIO 1: AFTER(!) SAP HANA SPS12 is available we could use hdbnsutil --sr_stateConfiguration
-SAPHanaTopologyVersion="0.163.0"
+SAPHanaTopologyVersion="0.163.1"
 #
 # Initialization:
 timeB=$(date '+%s')


### PR DESCRIPTION
As we already have 0.163.0 in SLE-15, we need to bump the version to include the latest fixes.