### PR TITLE
Allow virtual host names for SAPHanaController and SAPHanaTopology (bsc#1098979)

### DIFF
--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -1086,6 +1086,7 @@ function register_hana_secondary()
     super_ocf_log info "FLOW $FUNCNAME ($*)"
     local rc=2;
     local remoteInstance="";
+    local remoteHanaHost="";
     if is_the_master_nameserver; then
         remoteInstance=$InstanceNr
 
@@ -1115,8 +1116,12 @@ function register_hana_secondary()
                hanaRM="--mode=$sr_mode"
            fi
            set_hana_attribute "$NODENAME" "$sr_name" ${ATTR_NAME_HANA_SEC[@]}
-           super_ocf_log info "ACT: SAPHANA REGISTER: hdbnsutil -sr_register --remoteHost=$remoteHost --remoteInstance=$remoteInstance $hanaRM $hanaOM --name=$sr_name"
-           HANA_CALL --timeout inf --use-su --cmd "hdbnsutil -sr_register --remoteHost=$remoteHost --remoteInstance=$remoteInstance $hanaRM $hanaOM --name=$sr_name"; rc=$?
+           remoteHanaHost=$(get_hana_attribute "$remoteHost" ${ATTR_NAME_HANA_VHOST[@]})
+           if [ -z "$remoteHanaHost" ]; then
+               remoteHanaHost=$remoteHost
+           fi
+           super_ocf_log info "ACT: SAPHANA REGISTER: hdbnsutil -sr_register --remoteHost=$remoteHanaHost --remoteInstance=$remoteInstance $hanaRM $hanaOM --name=$sr_name"
+           HANA_CALL --timeout inf --use-su --cmd "hdbnsutil -sr_register --remoteHost=$remoteHanaHost --remoteInstance=$remoteInstance $hanaRM $hanaOM --name=$sr_name"; rc=$?
         else
            super_ocf_log info "ACT: SAPHANA: DROP REGISTER because AUTOMATED_REGISTER is set to FALSE"
            rc=1

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -888,7 +888,7 @@ function sht_monitor_clone() {
        vName=$(get_hana_attribute ${NODENAME} ${ATTR_NAME_HANA_VHOST[@]} "${NODENAME}")
     fi
     # last fallback, if neither the HANA call NOR the Attribute "knows" the vName - try the local hostname
-    if [ -n "$vName" ]; then
+    if [ -z "$vName" ]; then
        vName=${NODENAME}
     fi
     hanaANSWER=$(HANA_CALL --timeout $HANA_CALL_TIMEOUT --cmd "landscapeHostConfiguration.py --sapcontrol=1" 2>/dev/null); hanalrc="$?"


### PR DESCRIPTION
These patches by @fmherschel enable SAPHanaController and SAPHanaTopology to handle virtual host names correctly. According to the comments of Bug 1098979, it  has been verified by the customer.