### PR TITLE
SAPHanaSR-monitor: fix tolower() issue, which seems to be an artifact from a2p (Awk to Perl)

### DIFF
--- a/SAPHana/bin/SAPHanaSR-monitor
+++ b/SAPHana/bin/SAPHanaSR-monitor
@@ -219,7 +219,7 @@ sub processMonitor() {
     #
     $sid=$sids[0];   # currently ony one sid is supported
     ( $sid, $ino ) = split(":", $sid);
-    $sid=tolower("$sid");
+    $sid=lc("$sid");
     get_hana_attributes($sid, \%Host, \%HName, \%Global, \%GName, \%Site,   \%SName);
     if ( keys(%Host) == 0 ) {
         printf "No attributes found for SID=%s\n", $sid;


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=39267