### PR TITLE
Action timeouts defaults fix

### DIFF
--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -269,13 +269,13 @@ The resource agent uses the following four interfaces provided by SAP:
 </parameters>
 
 <actions>
-    <action name="start"   timeout="180" />
-    <action name="stop"    timeout="240" />
+    <action name="start"   timeout="3600" />
+    <action name="stop"    timeout="3600" />
     <action name="status"  timeout="60" />
-    <action name="monitor" depth="0" timeout="60" interval="120" />
-    <action name="monitor" depth="0" timeout="60" interval="121" role="Slave" />
-    <action name="monitor" depth="0" timeout="60" interval="119" role="Master" />
-    <action name="promote" timeout="320" />
+    <action name="monitor" depth="0" timeout="700" interval="60" />
+    <action name="monitor" depth="0" timeout="700" interval="61" role="Slave" />
+    <action name="monitor" depth="0" timeout="700" interval="60" role="Master" />
+    <action name="promote" timeout="3600" />
     <action name="demote"  timeout="320" />
     <action name="validate-all" timeout="5" />
     <action name="meta-data" timeout="5" />

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -189,10 +189,10 @@ SAPHanaTopology scans the output table of landscapeHostConfiguration.py to ident
     </parameter>
 </parameters>
 <actions>
-    <action name="start" timeout="180" />
-    <action name="stop" timeout="60" />
+    <action name="start" timeout="600" />
+    <action name="stop" timeout="300" />
     <action name="status" timeout="60" />
-    <action name="monitor" depth="0" timeout="60" interval="60" />
+    <action name="monitor" depth="0" timeout="600" interval="10" />
     <action name="validate-all" timeout="5" />
     <action name="meta-data" timeout="5" />
     <action name="methods" timeout="5" />


### PR DESCRIPTION
As with the resource agents for automating SAP HANA Scale-Up System Replication, the default action timeouts of the resource agents for automating SAPHana-Scale-Out System Replication also don't match the official recommendations from SUSE and Red Hat.

These commits align the default values in the documentation with the official recommendations.