### PR TITLE
bsc#1182545 - make action start/stop timeouts configurable

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes
@@ -1,7 +1,15 @@
 -------------------------------------------------------------------
-Thu Mar  4 13:35:53 UTC 2021 - abriel@suse.com
+Thu Mar  4 18:00:41 UTC 2021 - abriel@suse.com
 
 - change version to 0.164.2
+- The resource start and stop timeout is now configurable by
+  increasing the timeout for the action 'start' and/or 'stop'.
+  We will use 95% of this action timeouts to calculate the new
+  resource start and stop timeout for the 'WaitforStarted' and
+  'WaitforStopped' functions. If the new, calculated timeout value
+  is less than '3600', it will be set to '3600', so that we do not
+  decrease this timeout by accident
+  (bsc#1182545)
 - add return codes for saphana_stop and saphana_StopSystem
   (bsc#1182115)
 - man page SAPhanaSR-ScaleOut minor mistakes

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -64,6 +64,7 @@ HANA_STATE_SECONDARY=1
 HANA_STATE_STANDALONE=2
 HANA_STATE_DEFECT=3
 HANA_CALL_TIMEOUT=120
+HANA_STD_ACTION_TIMEOUT=3600
 
 debug_attributes=0
 
@@ -310,7 +311,7 @@ function dequote()
     local rc=0; tr -d '"'; return $rc
 }
 
-# function: version: cpmpare two HANA version strings
+# function: version: compare two HANA version strings
 function ver_lt() {
     ocf_version_cmp $1 $2
     test $? -eq 0 && return 0 || return 1
@@ -331,7 +332,7 @@ function ver_ge() {
     test $? -eq 2 -o $? -eq 1 && return 0 || return 1
 }
 #
-# function: version: cpmpare two HANA version strings
+# function: version: compare two HANA version strings
 #
 function version() {
     if [ $# -eq 3 ]; then
@@ -349,6 +350,28 @@ function version() {
     fi
 }
 
+# function: get_action_timeout
+# output:  action timeout
+#
+# timeOut = max(3600, 95%(actionTimeOut))
+#
+function get_action_timeout() {
+    super_ocf_log info "FLOW $FUNCNAME ($*)"
+    # $OCF_RESKEY_CRM_meta_timeout is the timeout of the current running action in ms
+    local actionTimeOut="${OCF_RESKEY_CRM_meta_timeout:-$HANA_STD_ACTION_TIMEOUT}"
+    local stdTimeOut="$HANA_STD_ACTION_TIMEOUT"
+    local actTimeOutPercent=95 # 95% to left 5% for the rest of the resource agent action
+
+    # 95%(actionTimeOut)
+    ((timeout = actionTimeOut * actTimeOutPercent/1000))
+    # max(3600, 95%(actionTimeOut))
+    if [ -z "$timeout" ] || [ "$timeout" -lt "$stdTimeOut" ]; then
+        timeout=$stdTimeOut
+    fi
+    super_ocf_log info "actionTimeout: action timeout was '$actionTimeOut', now changed to '$timeout'"
+    super_ocf_log info "FLOW $FUNCNAME"
+    echo $timeout
+}
 
 #
 # function: is_clone - report, if resource is configured as a clone (also master/slave)
@@ -1211,8 +1234,9 @@ function saphana_start() {
         fi
         if [ $rc -eq 0 ]
         then
-            # TODO: PRIO9: something more dynamic than 3600 seconds in WaitforStarted
-            output=$($SAPCONTROL -nr $InstanceNr -function WaitforStarted 3600 1)
+            # DONE: PRIO9: something more dynamic than 3600 seconds in WaitforStarted
+            HANA_ACTION_TIMEOUT=$(get_action_timeout)
+            output=$($SAPCONTROL -nr $InstanceNr -function WaitforStarted $HANA_ACTION_TIMEOUT 1)
             if [ $? -eq 0 ]
             then
                 super_ocf_log info "ACT: SAPHANA: System $SID-$InstanceName started: $output"
@@ -1259,7 +1283,8 @@ function saphana_stopSystem() {
      super_ocf_log info "ACT: SAPHANA STOP: Stopping System $SID-$InstanceName: $output"
   fi
   if [ $rc -eq 0 ]; then
-      output=$($SAPCONTROL -nr $InstanceNr -function WaitforStopped 3600 1)
+      HANA_ACTION_TIMEOUT=$(get_action_timeout)
+      output=$($SAPCONTROL -nr $InstanceNr -function WaitforStopped $HANA_ACTION_TIMEOUT 1)
       if [ $? -eq 0 ]; then
           super_ocf_log info "ACT: SAPHANA: System $SID-$InstanceName stopped: $output"
           rc=$OCF_SUCCESS

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -358,12 +358,18 @@ function version() {
 function get_action_timeout() {
     super_ocf_log info "FLOW $FUNCNAME ($*)"
     # $OCF_RESKEY_CRM_meta_timeout is the timeout of the current running action in ms
-    local actionTimeOut="${OCF_RESKEY_CRM_meta_timeout:-$HANA_STD_ACTION_TIMEOUT}"
+    local actionTimeOut="$OCF_RESKEY_CRM_meta_timeout"
     local stdTimeOut="$HANA_STD_ACTION_TIMEOUT"
     local actTimeOutPercent=95 # 95% to left 5% for the rest of the resource agent action
+    if [ -z "$actionTimeOut" ]; then
+        actionTimeOut="$stdTimeOut"
+    else
+        # actionTimeOut in seconds
+        ((actionTimeOut = actionTimeOut/1000))
+    fi
 
     # 95%(actionTimeOut)
-    ((timeout = actionTimeOut * actTimeOutPercent/1000))
+    ((timeout = actionTimeOut * actTimeOutPercent/100))
     # max(3600, 95%(actionTimeOut))
     if [ -z "$timeout" ] || [ "$timeout" -lt "$stdTimeOut" ]; then
         timeout=$stdTimeOut


### PR DESCRIPTION
The resource start and stop timeout is now configurable by increasing the timeout for the action 'start' and/or 'stop'. We will use 95% of this action timeouts to calculate the new resource start and stop timeout for the 'WaitforStarted' and 'WaitforStopped' functions. If the new, calculated timeout value is less than '3600' (now handled as HANA_STD_ACTION_TIMEOUT), it will be set to '3600', so that we do not decrease this timeout by accident (bsc#1182545)