### PR TITLE
SAPHanaTopology: Add log messages for timeout 

### DIFF
--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -377,9 +377,12 @@ function HANA_CALL()
                   #
                   # on timeout ...
                   #
-                  if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
-                      local second_output=""
-                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
+                  if [ $rc -eq 124 ]; then
+                      super_ocf_log warn "RA: HANA_CALL TIMEOUT after $timeOut seconds ($cmd)"
+                      if [ -n "$onTimeOut" ]; then
+                          local second_output=""
+                          second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
+                      fi
                   fi
                  ;;
     esac


### PR DESCRIPTION
Log messages category RA, if a HANA CALL Timeout occurs.