### PR TITLE
bsc#1182774 - add dedicated logging of HANA_CALL problems

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Tue Nov 23 18:33:36 UTC 2021 - abriel@suse.com
+Tue Dec 28 18:05:14 UTC 2021 - abriel@suse.com
 
 - change version to 0.181.0
 - Add systemd support for the resource agent to interact with the
@@ -9,6 +9,14 @@ Tue Nov 23 18:33:36 UTC 2021 - abriel@suse.com
   previous used SysV init script, we need to adapt the handling of
   sapstartsrv inside the resource agents to support both ways.
   (bsc#1189532, bsc#1189533)
+- add dedicated logging of HANA_CALL problems. So it will be now
+  possible to identify, if the called hana command or the needed
+  su command throws the error and for further hints we log the
+  stderr output.
+  Additional it is possible to get regular log messages for the
+  used commands, their return code and their stderr outout by
+  enabling the 'debug' mode of the ressource agents.
+  (bsc#1182774)
 
 -------------------------------------------------------------------
 Mon Aug  2 12:23:09 UTC 2021 - abriel@suse.com

--- a/SAPHana/SAPHanaSR-ScaleOut.changes
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Tue Dec 28 18:05:14 UTC 2021 - abriel@suse.com
+Mon Jan 10 09:57:21 UTC 2022 - abriel@suse.com
 
 - change version to 0.181.0
 - Add systemd support for the resource agent to interact with the
@@ -14,8 +14,8 @@ Tue Dec 28 18:05:14 UTC 2021 - abriel@suse.com
   su command throws the error and for further hints we log the
   stderr output.
   Additional it is possible to get regular log messages for the
-  used commands, their return code and their stderr outout by
-  enabling the 'debug' mode of the ressource agents.
+  used commands, their return code and their stderr output by
+  enabling the 'debug' mode of the resource agents.
   (bsc#1182774)
 
 -------------------------------------------------------------------

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -662,7 +662,7 @@ function HANA_CALL()
                   super_ocf_log debug "DBG: RA ==== action HANA_CALL (cmd is '$cmd', rc is '$rc', stderr from su is '$suErr', stderr from cmd is '$cmdErr') ===="
                   # on rc=1 - retry to improve the behavior in AD environments
                   if [ $rc -eq 1 ]; then
-                      super_ocf_log warn "HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
+                      super_ocf_log warn "RA: HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
                       if [ "$cmdErr" == "NA" ]; then
                           # seems something was going wrong with the 'pre_cmd' (su)
                           super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
@@ -673,7 +673,7 @@ function HANA_CALL()
                   # on timeout ...
                   #
                   if [ $rc -eq 124 ]; then
-                      super_ocf_log warn "HANA_CALL timed out after $timeOut seconds running command '$cmd'"
+                      super_ocf_log warn "RA: HANA_CALL timed out after $timeOut seconds running command '$cmd'"
                   fi
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -34,7 +34,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaControllerVersion="0.181.0.1123.1923"
+SAPHanaControllerVersion="0.181.0.1226.1907"
 # Resource Agent Generation
 RAG="2.0"
 
@@ -649,16 +649,35 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  output=$(timeout --foreground -s 9 $timeOut $pre_cmd "$pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                  errExt=$(date '+%s')
+                  su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
+                  cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
+                  cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}
+
+                  output=$(timeout --foreground -s 9 "$timeOut" "$pre_cmd" "($pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
+
+                  output=$(if [ -f "$cmd_out_log" ]; then cat "$cmd_out_log"; rm -f "$cmd_out_log"; fi)
+                  suErr=$(if [ -f "$su_err_log" ]; then cat "$su_err_log"; rm -f "$su_err_log"; else echo "NA"; fi)
+                  cmdErr=$(if [ -f "$cmd_err_log" ]; then cat "$cmd_err_log"; rm -f "$cmd_err_log"; else echo "NA"; fi)
+                  super_ocf_log debug "DBG: RA ==== action HANA_CALL (cmd is '$cmd', rc is '$rc', stderr from su is '$suErr', stderr from cmd is '$cmdErr') ===="
+                  # on rc=1 - retry to improve the behavior in AD environments
+                  if [ $rc -eq 1 ]; then
+                      super_ocf_log warn "HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
+                      if [ "$cmdErr" == "NA" ]; then
+                          # seems something was going wrong with the 'pre_cmd' (su)
+                          super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
+                          output=$(timeout --foreground -s 9 "$timeOut" "$pre_cmd" "$pre_script; timeout -s 9 $timeOut /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                      fi
+                  fi
                   #
                   # on timeout ...
                   #
-                  if [ "$rc" -eq 124 ]; then
-                      super_ocf_log warn "RA: HANA_CALL TIMEOUT after $timeOut seconds running command '$cmd'"
-                      if [ -n "$onTimeOut" ]; then
-                          local second_output=""
-                          second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
-                      fi
+                  if [ $rc -eq 124 ]; then
+                      super_ocf_log warn "HANA_CALL timed out after $timeOut seconds running command '$cmd'"
+                  fi
+                  if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
+                      local second_output=""
+                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
                   fi
                  ;;
     esac

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -572,9 +572,9 @@ scoring_crm_master()
             read rolePatt syncPatt score <<< $scan
             if grep "$rolePatt" <<< "$roles"; then
                if grep "$syncPatt" <<< "$sync"; then
-                  super_ocf_log info "SCORE: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
-                  super_ocf_log info "SCORE: scoring_crm_master: sync($sync) is  matching syncPattern ($syncPatt)"
-                  super_ocf_log info "SCORE: scoring_crm_master: set score $score"
+                  super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
+                  super_ocf_log info "DEC: scoring_crm_master: sync($sync) is  matching syncPattern ($syncPatt)"
+                  super_ocf_log info "DEC: scoring_crm_master: set score $score"
                   skip=1
                   myScore=$score
                fi
@@ -1718,7 +1718,7 @@ function saphana_start_primary()
             esac
             my_role=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_ROLES[@]}")
             my_role="${my_lss}:${my_srr}:${my_role}"
-            super_ocf_log info "SCORE: saphana_start_primary: scoring_crm_master($my_role,$my_sync)"
+            super_ocf_log info "DEC: saphana_start_primary: scoring_crm_master($my_role,$my_sync)"
             scoring_crm_master "$my_role" "$my_sync"
             ;;
         register ) # process a REGISTER
@@ -2733,7 +2733,7 @@ function saphana_monitor_primary()
             my_hana_role="${my_lss}:${my_srr}:${my_role}"
             if ocf_is_probe; then
                 rc=$OCF_SUCCESS
-                super_ocf_log info "SCORE: saphana_monitor_primary: (1) scoring_crm_master($my_hana_role,$my_sync)"
+                super_ocf_log info "DEC: saphana_monitor_primary: (1) scoring_crm_master($my_hana_role,$my_sync)"
                 scoring_crm_master "$my_hana_role" "$my_sync"
             else
                 LPTloc=$(date '+%s')
@@ -2825,7 +2825,7 @@ function saphana_monitor_primary()
                           ;;
                    esac
                 fi
-                super_ocf_log info "SCORE: saphana_monitor_primary: (2) scoring_crm_master($my_role,$my_sync)"
+                super_ocf_log info "DEC: saphana_monitor_primary: (2) scoring_crm_master($my_role,$my_sync)"
                 scoring_crm_master "$my_role" "$my_sync"
             fi
             ;;
@@ -2961,7 +2961,7 @@ function saphana_monitor_secondary()
                     #
                     my_hana_role="${my_lss}:${my_srr}:${my_role}"
                     super_ocf_log info "DEC: scoring $my_hana_role : $sync_attr"
-                    super_ocf_log info "SCORE: saphana_monitor_secondary: scoring_crm_master($my_hana_role,$sync_attr)"
+                    super_ocf_log info "DEC: saphana_monitor_secondary: scoring_crm_master($my_hana_role,$sync_attr)"
                     scoring_crm_master "$my_hana_role" "$sync_attr"
                     ;;
                 SFAIL ) # This is currently NOT a possible node to promote

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -26,7 +26,7 @@
 #
 #######################################################################
 # DONE PRIO 1: AFTER(!) SAP HANA SPS12 is available we could use hdbnsutil --sr_stateConfiguration
-SAPHanaTopologyVersion="0.181.0.1123.2015"
+SAPHanaTopologyVersion="0.181.0.1228.1907"
 #
 # Initialization:
 timeB=$(date '+%s')
@@ -373,7 +373,26 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  output=$(timeout $timeOut $pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                  errExt=$(date '+%s')
+                  su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
+                  cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
+                  cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}
+
+                  output=$(timeout "$timeOut" "$pre_cmd" "($pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
+
+                  output=$(if [ -f "$cmd_out_log" ]; then cat "$cmd_out_log"; rm -f "$cmd_out_log"; fi)
+                  suErr=$(if [ -f "$su_err_log" ]; then cat "$su_err_log"; rm -f "$su_err_log"; else echo "NA"; fi)
+                  cmdErr=$(if [ -f "$cmd_err_log" ]; then cat "$cmd_err_log"; rm -f "$cmd_err_log"; else echo "NA"; fi)
+                  super_ocf_log debug "DBG: RA ==== action HANA_CALL (cmd is '$cmd', rc is '$rc', stderr from su is '$suErr', stderr from cmd is '$cmdErr') ===="
+                  # on rc=1 - retry to improve the behavior in AD environments
+                  if [ $rc -eq 1 ]; then
+                      super_ocf_log warn "HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
+                      if [ "$cmdErr" == "NA" ]; then
+                          # seems something was going wrong with the 'pre_cmd' (su)
+                          super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."
+                          output=$(timeout "$timeOut" "$pre_cmd" "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
+                      fi
+                  fi
                   #
                   # on timeout ...
                   #

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -386,7 +386,7 @@ function HANA_CALL()
                   super_ocf_log debug "DBG: RA ==== action HANA_CALL (cmd is '$cmd', rc is '$rc', stderr from su is '$suErr', stderr from cmd is '$cmdErr') ===="
                   # on rc=1 - retry to improve the behavior in AD environments
                   if [ $rc -eq 1 ]; then
-                      super_ocf_log warn "HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
+                      super_ocf_log warn "RA: HANA_CALL stderr from command '$pre_cmd' is '$suErr', stderr from command '$cmd' is '$cmdErr'"
                       if [ "$cmdErr" == "NA" ]; then
                           # seems something was going wrong with the 'pre_cmd' (su)
                           super_ocf_log warn "DEC: HANA_CALL returned '1' for command '$pre_cmd'. Retry once."


### PR DESCRIPTION
add dedicated logging of HANA_CALL problems. So it will be now possible to identify, if the called hana command or the needed su command throws the error and for further hints we log the stderr output.
Additional it is possible to get regular log messages for the used commands, their return code and their stderr output by enabling the 'debug' mode of the resource agents.
This will work even if the sidadm user is using a 'bash' or a 'csh' as login shell
(bsc#1182774)

exchange 'SCORE' to 'DEC' inside the log messages to please the log filter