### PR TITLE
bsc#1189540 - add switch 'cib_access' to the SAPHanaSrMultiTarget hook

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes
@@ -17,6 +17,13 @@ Mon Jan 10 09:57:21 UTC 2022 - abriel@suse.com
   used commands, their return code and their stderr output by
   enabling the 'debug' mode of the resource agents.
   (bsc#1182774)
+- add switch 'cib_access' to the SAPHanaSrMultiTarget hook to give
+  control over the hook runtime.
+  Default is 'all-on' which means there are 3 cib calls performed
+  inside the hook script.
+  Changing the value of 'cib_access' inside the global.ini file to
+  'site-on' to perform the absolute minimum cib calls (only one)
+  (bsc#1189540)
 
 -------------------------------------------------------------------
 Mon Aug  2 12:23:09 UTC 2021 - abriel@suse.com

--- a/SAPHana/srHook/SAPHanaSrMultiTarget.py
+++ b/SAPHana/srHook/SAPHanaSrMultiTarget.py
@@ -21,13 +21,15 @@ To use this HA/DR hook provide please add the following lines (or similar) to yo
     [ha_dr_provider_SAPHanaSrMultiTarget]
     provider = SAPHanaSrMultiTarget
     path = /usr/share/SAPHanaSR-ScaleOut
+    cib_access = all-on
     execution_order = 1
 
     [trace]
     ha_dr_saphanasr = info
 """
-fhSRHookVersion = "0.180.0.0423.1704"
-srHookGen = "2.0"
+fhSRHookVersion = "0.181.0.0110.1727"
+srHookGen = "2.1"
+cib_access_dflt = "all-on"
 
 try:
     class SAPHanaSrMultiTarget(HADRBase):
@@ -36,7 +38,14 @@ try:
             # delegate construction to base class
             super(SAPHanaSrMultiTarget, self).__init__(*args, **kwargs)
             method = "init"
-            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__, method, fhSRHookVersion))
+            if self.config.hasKey("cib_access"):
+                self.cib_access = self.config.get("cib_access")
+                # first step, should be removed later
+                if self.cib_access != "site-on":
+                    self.cib_access = "all-on"
+            else:
+                self.cib_access = cib_access_dflt
+            self.tracer.info("{0}.{1}() version {2}, hookGeneration {3}, cib_access {4}".format(self.__class__.__name__, method, fhSRHookVersion, srHookGen, self.cib_access))
             mySID = os.environ.get('SAPSYSTEMNAME')
             mysid = mySID.lower()
             myCMD = "sudo /usr/sbin/crm_attribute -n hana_{1}_gsh -v {0}  -l reboot".format(srHookGen, mysid)
@@ -124,7 +133,7 @@ try:
         def srConnectionChanged(self, ParamDict, **kwargs):
             method = "srConnectionChanged"
             """ finally we got the srConnection hook :) """
-            self.tracer.info("{0}.{1}() method called with Dict={2} (version {3})".format(self.__class__.__name__, method, ParamDict, fhSRHookVersion))
+            self.tracer.info("{0}.{1}() method called with Dict={2} (version {3}) and cib_access {4}".format(self.__class__.__name__, method, ParamDict, fhSRHookVersion, self.cib_access))
             # myHostname = socket.gethostname()
             # myDatebase = ParamDict["database"]
             mySystemStatus = ParamDict["system_status"]
@@ -133,11 +142,13 @@ try:
             myInSync = ParamDict["is_in_sync"]
             myReason = ParamDict["reason"]
             mySite = ParamDict["siteName"]
-            myCMD = "sudo /usr/sbin/crm_attribute -n hana_{1}_gsh -v {0} -l reboot".format(srHookGen, mysid)
-            rc = os.system(myCMD)
-            myMSG = "CALLING CRM: <{0}> rc={1}".format(myCMD, rc)
-            self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
-            self.tracer.info("{0}.{1}() Running srHookGeneration {2}, see attribute hana_{3}_gsh too\n".format(self.__class__.__name__, method, srHookGen, mysid))
+            # if self.cib_access != "all-off" and self.cib_access != "glob-off":
+            if self.cib_access == "all-on" or self.cib_access == "glob-on" or self.cib_access == "site-off":
+                myCMD = "sudo /usr/sbin/crm_attribute -n hana_{1}_gsh -v {0} -l reboot".format(srHookGen, mysid)
+                rc = os.system(myCMD)
+                myMSG = "CALLING CRM: <{0}> rc={1}".format(myCMD, rc)
+                self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
+                self.tracer.info("{0}.{1}() Running srHookGeneration {2}, see attribute hana_{3}_gsh too\n".format(self.__class__.__name__, method, srHookGen, mysid))
             if mySystemStatus == 15:
                 mySRS = "SOK"
             else:
@@ -154,40 +165,46 @@ try:
                 myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
                 self.tracer.info("{0}.{1}() was called with empty site name. Ignoring call.".format(self.__class__.__name__, method))
             else:
-                # check if global Hook attribute exists
-                myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_glob_srHook -G" % (mysid)
-                rc = os.system(myCMD)
-                if rc == 0:
-                    # found global Hook attribute, write both (old and new) attributes
-                    # for compatibility reasons
-                    myCMD = "sudo /usr/sbin/crm_attribute -n hana_{0}_glob_srHook -v {1} -t crm_config -s SAPHanaSR".format(mysid, mySRS)
+                # if self.cib_access != "all-off" and self.cib_access != "glob-off":
+                if self.cib_access == "all-on" or self.cib_access == "glob-on" or self.cib_access == "site-off":
+                    # check if global Hook attribute exists
+                    myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_glob_srHook -G" % (mysid)
+                    rc = os.system(myCMD)
+                    if rc == 0:
+                        # found global Hook attribute, write both (old and new) attributes
+                        # for compatibility reasons
+                        myCMD = "sudo /usr/sbin/crm_attribute -n hana_{0}_glob_srHook -v {1} -t crm_config -s SAPHanaSR".format(mysid, mySRS)
+                        rc = os.system(myCMD)
+                        myMSG = "CALLING CRM: <{0}> rc={1}".format(myCMD, rc)
+                        self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
+
+                # if self.cib_access != "all-off" and self.cib_access != "site-off":
+                # if self.cib_access == "all-on" or self.cib_access == "site-on" or self.cib_access == "glob-off":
+                if self.cib_access == "all-on" or self.cib_access == "site-on":
+                    myCMD = "sudo /usr/sbin/crm_attribute -n hana_{0}_site_srHook_{1} -v {2} -t crm_config -s SAPHanaSR".format(mysid, mySite, mySRS)
                     rc = os.system(myCMD)
                     myMSG = "CALLING CRM: <{0}> rc={1}".format(myCMD, rc)
                     self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
-                myCMD = "sudo /usr/sbin/crm_attribute -n hana_{0}_site_srHook_{1} -v {2} -t crm_config -s SAPHanaSR".format(mysid, mySite, mySRS)
-                rc = os.system(myCMD)
-                myMSG = "CALLING CRM: <{0}> rc={1}".format(myCMD, rc)
-                self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
-                #
-                if rc != 0:
                     #
-                    # FALLBACK
-                    # sending attribute to the cluster failed - using fallback method and write status to a file - RA to pick-up the value during next SAPHanaController monitor operation
-                    #
-                    myMSG = "sending attribute to the cluster failed - using local file as fallback"
-                    self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
-                    #
-                    # cwd of hana is /hana/shared/<SID>/HDB00/<hananode> we use a relative path to cwd this gives us a <sid>adm permitted directory
-                    #     however we go one level up (..) to have the file accessible for all SAP HANA swarm nodes
-                    #
-                    fallbackFileObject = open("../.crm_attribute.stage.{0}".format(mySite), "w")
-                    fallbackFileObject.write("hana_{0}_site_srHook_{1} = {2}".format(mysid, mySite, mySRS))
-                    fallbackFileObject.close()
-                    #
-                    # release the stage file to the original name (move is used to be atomic)
-                    #      .crm_attribute.stage.<site> is renamed to .crm_attribute.<site>
-                    #
-                    os.rename("../.crm_attribute.stage.{0}".format(mySite), "../.crm_attribute.{0}".format(mySite))
+                    if rc != 0:
+                        #
+                        # FALLBACK
+                        # sending attribute to the cluster failed - using fallback method and write status to a file - RA to pick-up the value during next SAPHanaController monitor operation
+                        #
+                        myMSG = "sending attribute to the cluster failed - using local file as fallback"
+                        self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
+                        #
+                        # cwd of hana is /hana/shared/<SID>/HDB00/<hananode> we use a relative path to cwd this gives us a <sid>adm permitted directory
+                        #     however we go one level up (..) to have the file accessible for all SAP HANA swarm nodes
+                        #
+                        fallbackFileObject = open("../.crm_attribute.stage.{0}".format(mySite), "w")
+                        fallbackFileObject.write("hana_{0}_site_srHook_{1} = {2}".format(mysid, mySite, mySRS))
+                        fallbackFileObject.close()
+                        #
+                        # release the stage file to the original name (move is used to be atomic)
+                        #      .crm_attribute.stage.<site> is renamed to .crm_attribute.<site>
+                        #
+                        os.rename("../.crm_attribute.stage.{0}".format(mySite), "../.crm_attribute.{0}".format(mySite))
             return 0
 except NameError as e:
     print("Could not find base class ({0})".format(e))

--- a/SAPHana/srHook/global.ini
+++ b/SAPHana/srHook/global.ini
@@ -7,6 +7,7 @@ execution_order = 1
 [ha_dr_provider_SAPHanaSrMultiTarget]
 provider = SAPHanaSrMultiTarget
 path = /usr/share/SAPHanaSR-ScaleOut
+cib_access = all-on
 execution_order = 2
 
 [trace]


### PR DESCRIPTION
to give a little bit control over the hook runtime.
Default is 'all-on' which means there are 3 cib calls performed inside the hook script. Changing the value of 'cib_access' inside the global.ini file to 'site-on' to perform the absolute minimum cib calls (only one)
(bsc#1189540)