### PR TITLE
SAPHana*: follow OCF standard for version and OCF version in metadata

### DIFF
--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -166,8 +166,8 @@ function saphana_meta_data() {
     cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHanaController">
-<version>$SAPHanaControllerVersion</version>
+<resource-agent name="SAPHanaController" version="$SAPHanaControllerVersion">
+<version>1.0</version>
 
 <shortdesc lang="en">Manages two SAP HANA database systems in system replication (SR).</shortdesc>
 <longdesc lang="en">

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -132,8 +132,8 @@ function sht_meta_data() {
 	cat <<END
 <?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHanaTopology">
-    <version>$SAPHanaTopologyVersion</version>
+<resource-agent name="SAPHanaTopology" version="$SAPHanaTopologyVersion">
+    <version>1.0</version>
     <shortdesc lang="en">Analyzes SAP HANA System Replication Topology.</shortdesc>
     <longdesc lang="en">This RA analyzes the SAP HANA topology and "sends" all findings via the node status attributes to
         all nodes in the cluster. These attributes are taken by the SAPHana RA to control the SAP Hana Databases.


### PR DESCRIPTION
Latest version of pcs will fail when these arent correct.

For reference from the main resource-agents repo:
https://github.com/ClusterLabs/resource-agents/pull/1700