### PR TITLE
change SAPHanaSR-manageAttr to support different pacemaker versions

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes_12
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_12
@@ -1,6 +1,9 @@
 -------------------------------------------------------------------
-Tue Jul  5 12:20:39 UTC 2022 - abriel@suse.com
+Tue Jul  5 13:15:38 UTC 2022 - abriel@suse.com
 
+- change SAPHanaSR-manageAttr to support the different behaviour of
+  'crmadmin -qD' in different pacemaker versions
+  (bsc#1200969)
 - fix HANA_CALL function to support MCOS environments again
   (bsc#1198780)
 - correct the order constraint in man page ocf_suse_SAPHanaTopology.7

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_12
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_12
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul  5 12:20:39 UTC 2022 - abriel@suse.com
+
+- fix HANA_CALL function to support MCOS environments again
+  (bsc#1198780)
+- correct the order constraint in man page ocf_suse_SAPHanaTopology.7
+  (bsc#1197239)
+
+-------------------------------------------------------------------
 Mon Jan 10 09:57:21 UTC 2022 - abriel@suse.com
 
 - change version to 0.181.0

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_15
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_15
@@ -1,6 +1,9 @@
 -------------------------------------------------------------------
-Tue Jul  5 12:20:39 UTC 2022 - abriel@suse.com
+Tue Jul  5 13:15:38 UTC 2022 - abriel@suse.com
 
+- change SAPHanaSR-manageAttr to support the different behaviour of
+  'crmadmin -qD' in different pacemaker versions
+  (bsc#1200969)
 - fix HANA_CALL function to support MCOS environments again
   (bsc#1198780)
 - correct the order constraint in man page ocf_suse_SAPHanaTopology.7

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_15
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_15
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul  5 12:20:39 UTC 2022 - abriel@suse.com
+
+- fix HANA_CALL function to support MCOS environments again
+  (bsc#1198780)
+- correct the order constraint in man page ocf_suse_SAPHanaTopology.7
+  (bsc#1197239)
+
+-------------------------------------------------------------------
 Mon Jan 10 09:57:21 UTC 2022 - abriel@suse.com
 
 - change version to 0.181.0

--- a/SAPHana/bin/SAPHanaSR-manageAttr
+++ b/SAPHana/bin/SAPHanaSR-manageAttr
@@ -1031,16 +1031,28 @@ chk_cluster_health() {
     done
 
     # get DC and check idle state
-    DC=$(crmadmin -Dq 2>&1 1>/dev/null)
-    if [ -n "$DC" ]; then
-        istate=$(crmadmin -q -S "$DC" 2>&1 1>/dev/null)
-    else
+    # Note: crmadmin in Pacemaker versions before 2.0.5/2.1.0 printed the
+    # --quiet result on stderr, hence checking this output sink first.
+    local ret
+    ret=0
+    DC=$(crmadmin -q -D 2>&1 1>/dev/null) || ret=$?
+    if [ -z "$DC" ]; then
+        DC=$(crmadmin -q -D 2>/dev/null) || ret=$?
+    fi
+    if [ -z "$DC" ] || [ "$ret" != 0 ]; then
         wr_info -eh "Could not detect the Designated Controller, please check cluster health."
         chk=1
+    else
+        istate=$(crmadmin -q -S "$DC" 2>&1 1>/dev/null) || ret=$?
     fi
-    if [ "$istate" != "S_IDLE" ]; then
-        wr_info -eh "Cluster NOT in state S_IDLE, but in state '$istate'. Please check."
+    if [ -z "$istate" ] || [ "$ret" != 0 ]; then
+        wr_info -eh "Cluster state 'unknown'. Please check."
         chk=1
+    else
+        if [ "$istate" != "S_IDLE" ]; then
+            wr_info -eh "Cluster NOT in state S_IDLE, but in state '$istate'. Please check."
+            chk=1
+        fi
     fi
 
     return $chk

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -649,7 +649,7 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  errExt=$(date '+%s')
+                  errExt=$(date '+%s%N')_${sid}adm
                   su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
                   cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -373,7 +373,7 @@ function HANA_CALL()
                   output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $cmd"); rc=$?
                   ;;
         *       )
-                  errExt=$(date '+%s')
+                  errExt=$(date '+%s%N')_${sid}adm
                   su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
                   cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
                   cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}


### PR DESCRIPTION
the behaviour of 'crmadmin -q -D' differs in different pacemaker versions.
crmadmin in pacemaker versions before 2.0.5/2.1.0 printed the --quiet result (essential query information) on stderr instead of stdout. And additional it printed the full query information on stdout. In newer pacemaker versions the behaviour is fixed (with bsc# 1178865) as described in the man page.
Additionally the command is now called correctly with '-q -D' instead of '-Dq', where the 'quiet' option was not recognized from some pacemaker versions.
(bsc#1200969)