### PR TITLE
replace HERE strings and HERE documents

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes_12
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_12
@@ -1,4 +1,21 @@
 -------------------------------------------------------------------
+Tue May 23 17:47:00 UTC 2023 - abriel@suse.com
+
+- Version bump to 0.185.0
+  * avoid explicid and implicid usage of /tmp filesystem to keep
+    the SAPHanaSR resource agents working even in situations with
+    /tmp filesystem full.
+    (bsc#1210728)
+  * fix the path for the HA/DR provider hook in the global.ini
+    examples to be useful
+    (bsc#1210573)
+  * update man pages:
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR-ScaleOut_basic_cluster.7
+    SAPHanaSrMultiTarget.py.7
+    SAPHanaSR.py.7
+
+-------------------------------------------------------------------
 Tue Nov 29 17:12:15 UTC 2022 - abriel@suse.com
 
 - Version bump to 0.184.1
@@ -11,7 +28,7 @@ Tue Nov 29 17:12:15 UTC 2022 - abriel@suse.com
   * add improvements from SAP to the RA scripts regarding the
     handling of the SAP tools 'HDB version', 'HDBSettings.sh' and
     'pycd' and the SAPHana log filter handling
-    (jsc#PED-1739)
+    (jsc#PED-1739, jsc#PED-2608)
   * fix SAPHanaSR-replay-archive to handle hb_report archives again
     (bsc#1198897)
   * fix for SAPHanaSR-monitor reporting "LPA status of one node is
@@ -109,11 +126,21 @@ Mon Aug  2 12:23:09 UTC 2021 - abriel@suse.com
 - handle 'leftover instances'
   if HANA is configured to have only one master name server, but
   no additional master name server candidates, there may be the
-  situation, where the master name serve died and so the landscape
+  situation, where the master name server died and so the landscape
   has no active name server anymore.
   But there are other instances running with active communication
   channels. To prevent data corruption or operations on outdated
   data, we identify and stop these 'leftover' instances.
+- add workaround for 'sapcontrol -function WaitforStopped'
+  terminating to early.
+  If the master name server dies and does not have a failover
+  candidate but there are still running worker nodes the command
+  'sapcontrol -function WaitforStopped' terminates to early and
+  does not wait till all the remaining worker nodes are down.
+  So the resource agent needs to wait during his 'stopSystem'
+  function till the last "partial" node is down before returning
+  a result to the cluster.
+  (bsc#1196650)
 - manual page updates:
   SAPHanaSR-ScaleOut.7 (bsc#1144442)
   SAPHanaSR-showAttr.8 (bsc#1144312)

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_15
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_15
@@ -1,4 +1,21 @@
 -------------------------------------------------------------------
+Tue May 23 17:47:00 UTC 2023 - abriel@suse.com
+
+- Version bump to 0.185.0
+  * avoid explicid and implicid usage of /tmp filesystem to keep
+    the SAPHanaSR resource agents working even in situations with
+    /tmp filesystem full.
+    (bsc#1210728)
+  * fix the path for the HA/DR provider hook in the global.ini
+    examples to be useful
+    (bsc#1210573)
+  * update man pages:
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR-ScaleOut_basic_cluster.7
+    SAPHanaSrMultiTarget.py.7
+    SAPHanaSR.py.7
+
+-------------------------------------------------------------------
 Tue Nov 29 17:13:37 UTC 2022 - abriel@suse.com
 
 - Version bump to 0.184.1
@@ -11,7 +28,7 @@ Tue Nov 29 17:13:37 UTC 2022 - abriel@suse.com
   * add improvements from SAP to the RA scripts regarding the
     handling of the SAP tools 'HDB version', 'HDBSettings.sh' and
     'pycd' and the SAPHana log filter handling
-    (jsc#PED-1739)
+    (jsc#PED-1739, jsc#PED-2608)
   * fix SAPHanaSR-replay-archive to handle hb_report archives again
     (bsc#1198897)
   * fix for SAPHanaSR-monitor reporting "LPA status of one node is
@@ -116,11 +133,21 @@ Mon Aug  2 12:23:09 UTC 2021 - abriel@suse.com
 - handle 'leftover instances'
   if HANA is configured to have only one master name server, but
   no additional master name server candidates, there may be the
-  situation, where the master name serve died and so the landscape
+  situation, where the master name server died and so the landscape
   has no active name server anymore.
   But there are other instances running with active communication
   channels. To prevent data corruption or operations on outdated
   data, we identify and stop these 'leftover' instances.
+- add workaround for 'sapcontrol -function WaitforStopped'
+  terminating to early.
+  If the master name server dies and does not have a failover
+  candidate but there are still running worker nodes the command
+  'sapcontrol -function WaitforStopped' terminates to early and
+  does not wait till all the remaining worker nodes are down.
+  So the resource agent needs to wait during his 'stopSystem'
+  function till the last "partial" node is down before returning
+  a result to the cluster.
+  (bsc#1196650)
 - manual page updates:
   SAPHanaSR-ScaleOut.7 (bsc#1144442)
   SAPHanaSR-showAttr.8 (bsc#1144312)

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -115,12 +115,11 @@ function saphana_usage() {
     local rc=0
     methods=$(saphana_methods)
     methods=$(echo $methods | tr ' ' '|')
-    cat <<-EOF
-    usage: $0 ($methods)
+    echo "    usage: $0 ($methods)
 
     $0 manages two SAP HANA databases in system replication.
 
-    The 'start'        operation starts the HANA instance or bring the "clone instance" to a WAITING status
+    The 'start'        operation starts the HANA instance or bring the \"clone instance\" to a WAITING status
     The 'stop'         operation stops the HANA instance
     The 'status'       operation reports whether the HANA instance is running
     The 'monitor'      operation reports whether the HANA instance seems to be working in multi-state it also needs to check the system replication status
@@ -130,8 +129,7 @@ function saphana_usage() {
     The 'validate-all' operation reports whether the parameters are valid
     The 'methods'      operation reports on the methods $0 supports
     The 'reload'       operation allows to adapt resource parameters
-
-EOF
+"
     return $rc
 }
 
@@ -154,10 +152,9 @@ function saphana_meta_data() {
     local rc=0
 # TODO PRIO2: Description including parameters to be reviewed for scale-out
 # TODO PRIO2: check whether default is PREFER_SITE_TAKEOVER=false, then correct this meta-data.
-    cat <<END
-<?xml version="1.0"?>
+echo '<?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHanaController" version="$SAPHanaControllerVersion">
+<resource-agent name="SAPHanaController" version="'$SAPHanaControllerVersion'">
 <version>1.0</version>
 
 <shortdesc lang="en">Manages two SAP HANA database systems in system replication (SR).</shortdesc>
@@ -194,7 +191,7 @@ The resource agent uses the following four interfaces provided by SAP:
    Interface is SQL query into HANA (system replication table).  The hdbsql query will be replaced by a python script
    "systemReplicationStatus.py" in SAP HANA SPS8 or 9.
    As long as we need to use hdbsql you need to set up secure store users for linux user root to be able to
-   access the SAP HANA database. You need to configure a secure store user key "SAPHANA${SID}SR" which can connect the SAP
+   access the SAP HANA database. You need to configure a secure store user key "SAPHANA'${SID}'SR" which can connect the SAP
    HANA database:
 
 5. saphostctrl
@@ -279,8 +276,7 @@ The resource agent uses the following four interfaces provided by SAP:
     <action name="methods" timeout="5" />
     <action name="reload" timeout="5" />
 </actions>
-</resource-agent>
-END
+</resource-agent>'
 return $rc
 }
 
@@ -559,16 +555,16 @@ scoring_crm_master()
     local skip=0
     local myScore=""
     for scan in "${SCORING_TABLE[@]}"; do
-        if [ $skip -eq 0 ]; then
-            read rolePatt syncPatt score <<< $scan
-            if grep "$rolePatt" <<< "$roles"; then
-               if grep "$syncPatt" <<< "$sync"; then
-                  super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
-                  super_ocf_log info "DEC: scoring_crm_master: sync($sync) is  matching syncPattern ($syncPatt)"
-                  super_ocf_log info "DEC: scoring_crm_master: set score $score"
-                  skip=1
-                  myScore=$score
-               fi
+        # $scan needs "" to prevent globbing, as the scoring tables include '.*'
+        read rolePatt syncPatt score < <(echo "$scan")
+        if [[ "$roles" =~ $rolePatt ]] ; then
+            # $syncPatt must NOT have "" for correct matching
+            if [[ "$sync" =~ $syncPatt ]] ; then
+                super_ocf_log info "DEC: scoring_crm_master: roles($roles) are matching pattern ($rolePatt)"
+                super_ocf_log info "DEC: scoring_crm_master: sync($sync) is matching syncPattern ($syncPatt)"
+                super_ocf_log info "DEC: scoring_crm_master: set score $score"
+                myScore=$score
+                break
             fi
         fi
     done
@@ -641,9 +637,9 @@ function HANA_CALL()
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
-                  su_err_log=/tmp/HANA_CALL_SU_RA_${errExt}
-                  cmd_out_log=/tmp/HANA_CALL_CMD_RA_OUT_${errExt}
-                  cmd_err_log=/tmp/HANA_CALL_CMD_RA_${errExt}
+                  su_err_log=/run/HANA_CALL_SU_RA_${errExt}
+                  cmd_out_log=/run/HANA_CALL_CMD_RA_OUT_${errExt}
+                  cmd_err_log=/run/HANA_CALL_CMD_RA_${errExt}
 
                   output=$(timeout --foreground -s 9 "$timeOut" $pre_cmd "($pre_script; timeout -s 9 $timeOut $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
@@ -2318,7 +2314,7 @@ function master_walk() {
                 super_ocf_log debug "DBG: Filter node by cluster node standby mode"
             else
                 nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}")
-                IFS=: read nNsConf nNsCurr nIsConf nIsCurr <<< "$nRole"
+                read nNsConf nNsCurr nIsConf nIsCurr < <(echo ${nRole//:/ })
                 super_ocf_log debug "DBG: site $site $nNsConf:$nNsCurr"
                 case "$nNsConf:$nNsCurr" in
                     master1:master  ) master1=$node; active_master=$node
@@ -2386,8 +2382,8 @@ is_active_nameserver_slave()
 {
   super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
   local rc=1 nRole="" nLsc=""  nSrmode="" nNsConf="" nNsCurr="" nIsConf="" nIsCurr=""
-  nRole=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_ROLES[@]}" | tr ':' ' ')
-  read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
+  nRole=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_ROLES[@]}")
+  read nNsConf nNsCurr nIsConf nIsCurr < <(echo ${nRole//:/ })
   case "$nNsConf:$nNsCurr" in
       slave:slave )
 	 # configured as slave and actual role also detected as slave
@@ -2415,7 +2411,7 @@ is_lost_nameserver_slave()
   super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
   local rc=1 nRole="" nLsc=""  nSrmode="" nNsConf="" nNsCurr="" nIsConf="" nIsCurr=""
   nRole=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_ROLES[@]}")
-  IFS=: read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
+  read nNsConf nNsCurr nIsConf nIsCurr < <(echo ${nRole//:/ })
   case "$nNsConf:$nNsCurr" in
       slave: )
 	 # configured as slave but actual role could not be figured out - treat as is_lost_nameserver_slave
@@ -2442,8 +2438,8 @@ function is_master_nameserver()
 {
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     local rc=1 nRole="" nLsc=""  nSrmode="" nNsConf="" nNsCurr="" nIsConf="" nIsCurr=""
-    nRole=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_ROLES[@]}" | tr ':' ' ')
-    read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
+    nRole=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_ROLES[@]}")
+    read nNsConf nNsCurr nIsConf nIsCurr < <(echo ${nRole//:/ })
     case "$nNsConf:$nNsCurr" in
         master[123]:master )
            rc=0

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -95,21 +95,19 @@ function sht_usage() {
     local rc=0
     methods=$(sht_methods)
     methods=$(echo $methods | tr ' ' '|')
-  cat <<-!
-	usage: $0 ($methods)
+    echo "usage: $0 ($methods)
 
     $0 manages a SAP HANA Instance as an HA resource.
 
-    The 'start'        operation starts the HANA instance or bring the "instance" to a WAITING (for primary) status
+    The 'start'        operation starts the HANA instance or bring the \"instance\" to a WAITING (for primary) status
     The 'stop'         operation stops the HANA instance
     The 'status'       operation reports whether the HANA instance is running
     The 'monitor'      operation reports whether the HANA instance seems to be working in multi-state configuration it also needs to check the system replication status
     The 'notify'       operation always returns SUCCESS
     The 'validate-all' operation reports whether the parameters are valid
     The 'methods'      operation reports on the methods $0 supports
-
-	!
-	return $rc
+"
+    return $rc
 }
 
 #
@@ -120,10 +118,9 @@ function sht_usage() {
 function sht_meta_data() {
     super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
     local rc=0
-	cat <<END
-<?xml version="1.0"?>
+    echo '<?xml version="1.0"?>
 <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
-<resource-agent name="SAPHanaTopology" version="$SAPHanaTopologyVersion">
+<resource-agent name="SAPHanaTopology" version="'$SAPHanaTopologyVersion'">
     <version>1.0</version>
     <shortdesc lang="en">Analyzes SAP HANA System Replication Topology.</shortdesc>
     <longdesc lang="en">This RA analyzes the SAP HANA topology and "sends" all findings via the node status attributes to
@@ -172,8 +169,8 @@ SAPHanaTopology scans the output table of landscapeHostConfiguration.py to ident
         <content type="string" default="120" />
     </parameter>
     <parameter name="DIR_EXECUTABLE" unique="0" required="0">
-        <longdesc lang="en">Path to the SAP Hana Instance executable directory. If not set the RA tries /usr/sap/\$SID/\$InstanceName/exe.
-        While InstanceName is the string of "HDB" and \$InstanceNumber for SAP Hana databases.
+        <longdesc lang="en">Path to the SAP Hana Instance executable directory. If not set the RA tries /usr/sap/$SID/$InstanceName/exe.
+        While InstanceName is the string of "HDB" and $InstanceNumber for SAP Hana databases.
         </longdesc>
         <shortdesc lang="en">Path to the SAP Hana Instance executable directory.</shortdesc>
         <content type="string" default="" />
@@ -188,9 +185,8 @@ SAPHanaTopology scans the output table of landscapeHostConfiguration.py to ident
     <action name="meta-data" timeout="5" />
     <action name="methods" timeout="5" />
 </actions>
-</resource-agent>
-END
-return $rc
+</resource-agent>'
+    return $rc
 }
 
 #
@@ -267,21 +263,20 @@ function set_hana_attribute()
 # methods: What methods/operations do we support?
 #
 function sht_methods() {
-  super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
-  local rc=0
-  cat <<-!
-    start
-    stop
-    status
-    monitor
-    notify
-    validate-all
-    methods
-    meta-data
-    usage
-    admin-setup
-	!
-	return $rc
+    super_ocf_log info "FLOW ${FUNCNAME[0]} ($*)"
+    local rc=0
+    echo "
+      start
+      stop
+      status
+      monitor
+      notify
+      validate-all
+      methods
+      meta-data
+      usage
+      admin-setup"
+    return $rc
 }
 
 #
@@ -365,9 +360,9 @@ function HANA_CALL()
                   ;;
         *       )
                   errExt=$(date '+%s%N')_${sid}adm
-                  su_err_log=/tmp/HANA_CALL_SU_TOP_${errExt}
-                  cmd_out_log=/tmp/HANA_CALL_CMD_TOP_OUT_${errExt}
-                  cmd_err_log=/tmp/HANA_CALL_CMD_TOP_${errExt}
+                  su_err_log=/run/HANA_CALL_SU_TOP_${errExt}
+                  cmd_out_log=/run/HANA_CALL_CMD_TOP_OUT_${errExt}
+                  cmd_err_log=/run/HANA_CALL_CMD_TOP_${errExt}
 
                   output=$(timeout "$timeOut" $pre_cmd "($pre_script; $cmd > $cmd_out_log) >& $cmd_err_log" 2>"$su_err_log"); rc=$?
 
@@ -741,8 +736,8 @@ function master_walk() {
               nSite=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_SITE[@]}")
               if [ "$site" = "$nSite" ]; then
                  # node of same site found
-                 nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}" | tr ':' ' ')
-                 read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
+                 nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}")
+                 read nNsConf nNsCurr nIsConf nIsCurr < <(echo ${nRole//:/ })
                  super_ocf_log debug "DBG: site $site $nNsConf:$nNsCurr"
                  case "$nNsConf:$nNsCurr" in
                     master1:master  ) master1=$node; active_master=$node
@@ -775,7 +770,6 @@ function master_walk() {
              declare -a masters
              masters=( $master1 $master2 $master3 )
              best_cold_master=${masters[0]}
-             #read best_cold_master rest <<<$master1 $master2 $master3
           fi
           super_ocf_log info "ACT ===> priorities for site $site master1=$master1 master2=$master2 master3=$master3 ==> active_master=$active_master best_cold_master=$best_cold_master"
           ;;
@@ -786,7 +780,6 @@ function master_walk() {
     declare -a masters
     masters=( $active_master $best_cold_master )
     the_master=${masters[0]}
-#   read the_master rest <<<$active_master $best_cold_master
    super_ocf_log info "ACT ===> master_walk: the_master=$the_master; priorities for site $site master1=$master1 master2=$master2 master3=$master3 ==> active_master=$active_master best_cold_master=$best_cold_master"
 }
 
@@ -917,8 +910,8 @@ function sht_stop_clone() {
     if [ "$hanalrc" -ge 124 ]; then
         # timeout of HANA_CALL, set role to '$nNsConf:shtdown:shtdown:shtdown'
         # to get the saphana_demote_clone to fail and stop the resource
-        nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}" | tr ':' ' ')
-        read nNsConf nNsCurr nIsConf nIsCurr <<< $nRole
+        nRole=$(get_hana_attribute ${node} "${ATTR_NAME_HANA_ROLES[@]}")
+        read nNsConf nNsCurr nIsConf nIsCurr < <(echo ${nRole//:/ })
         set_hana_attribute "${NODENAME}" "$nNsConf:shtdown:shtdown:shtdown" "${ATTR_NAME_HANA_ROLES[@]}"
         # and exit with 1 to let the stop fail
         tout=1


### PR DESCRIPTION
avoid explicit and implicit usage of /tmp filesystem to keep the SAPHanaSR resource agents working even in situations with /tmp filesystem full. (bsc#1210728)

As the bash older than 5.1 uses temporary files in /tmp to process HERE strings and HERE documents the resource agent has problems to work correctly, if /tmp filesystem is full. 
The idea is now to replace the HERE documents with the bash builtin 'echo' and the HERE strings with process substitutions (using pipes internally)  in combination with bash internal pattern substitution (avoiding 'tr' or redefining IFS)
 