### PR TITLE
bsc#1217830 - fix cluster state in SAPHanaSR-manageAttr

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes_12
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_12
@@ -1,4 +1,28 @@
 -------------------------------------------------------------------
+Wed Dec 13 18:28:57 UTC 2023 - abriel@suse.com
+
+- Version bump to 0.185.2
+  * fix cluster state in SAPHanaSR-manageAttr by supporting the
+    different behaviour of 'crmadmin -q -S' in different pacemaker
+    versions
+    (bsc#1217830)
+  * inside SAPHanaSR-hookHelper use the full path for the cibadmin
+    command to support non root users in special user environments
+    (bsc#1216484)
+  * if the SAPHanaSrMultiTarget hook has successfully reported a
+    SR event to the cluster a still existing fall-back state file
+    will be removed to prevent an override of an already reported
+    SR state.
+    (bsc#1215693)
+  * update man pages:
+    SAPHanaSR-ScaleOut.7
+    SAPHanaSR-ScaleOut_basic_cluster.7
+    SAPHanaSR_maintenance_examples.7
+    ocf_suse_SAPHanaTopology.7
+    ocf_suse_SAPHanaController.7
+    SAPHanaSR-showAttr.8
+
+-------------------------------------------------------------------
 Mon Aug 25 16:24:32 UTC 2023 - abriel@suse.com
 
 - Version bump to 0.185.1

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_15
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_15
@@ -1,4 +1,28 @@
 -------------------------------------------------------------------
+Wed Dec 13 18:38:57 UTC 2023 - abriel@suse.com
+
+- Version bump to 0.185.2
+  * fix cluster state in SAPHanaSR-manageAttr by supporting the
+    different behaviour of 'crmadmin -q -S' in different pacemaker
+    versions
+    (bsc#1217830)
+  * inside SAPHanaSR-hookHelper use the full path for the cibadmin
+    command to support non root users in special user environments
+    (bsc#1216484)
+  * if the SAPHanaSrMultiTarget hook has successfully reported a
+    SR event to the cluster a still existing fall-back state file
+    will be removed to prevent an override of an already reported
+    SR state.
+    (bsc#1215693)
+  * update man pages:
+    SAPHanaSR-ScaleOut.7
+    SAPHanaSR-ScaleOut_basic_cluster.7
+    SAPHanaSR_maintenance_examples.7
+    ocf_suse_SAPHanaTopology.7
+    ocf_suse_SAPHanaController.7
+    SAPHanaSR-showAttr.8
+
+-------------------------------------------------------------------
 Mon Aug 25 16:24:32 UTC 2023 - abriel@suse.com
 
 - Version bump to 0.185.1

--- a/SAPHana/SAPHanaSR-ScaleOut.spec
+++ b/SAPHana/SAPHanaSR-ScaleOut.spec
@@ -21,7 +21,7 @@ License:        GPL-2.0
 Group:          Productivity/Clustering/HA
 AutoReqProv:    on
 Summary:        Resource agents to control the HANA database in system replication setup
-Version:        0.185.1
+Version:        0.185.2
 Release:        0
 Url:            http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution
 Source0:        SAPHanaSR-ScaleOut-%{version}.tar.bz2

--- a/SAPHana/bin/SAPHanaSR-manageAttr
+++ b/SAPHana/bin/SAPHanaSR-manageAttr
@@ -1043,7 +1043,17 @@ chk_cluster_health() {
         wr_info -eh "Could not detect the Designated Controller, please check cluster health."
         chk=1
     else
+        # Note: crmadmin in Pacemaker versions before 2.1.2 printed the
+        # --quiet result (S_IDLE) on stderr instead of stdout
+        # on stdout there was an additonal, more chatty message like
+        # Status of crmd@hana01: S_IDLE (ok)
+        # as I'm not sure, which other messages may appear on stdout for all
+        # the 'old' pacemaker versions, I will check the stderr output first.
+        #
         istate=$(crmadmin -q -S "$DC" 2>&1 1>/dev/null) || ret=$?
+        if [ -z "$istate" ]; then
+            istate=$(crmadmin -q -S "$DC" 2>/dev/null) || ret=$?
+        fi
     fi
     if [ -z "$istate" ] || [ "$ret" != 0 ]; then
         wr_info -eh "Cluster state 'unknown'. Please check."


### PR DESCRIPTION
bsc#1217830
fix cluster state in SAPHanaSR-manageAttr by supporting the different behaviour of 'crmadmin -q -S' in different pacemaker versions
and prepare next maintenance update
