### PR TITLE
bsc#1216918 - Fix SAPHanaSR-hookHelper by using full pathnames for commands.

### DIFF
--- a/SAPHana/SAPHanaSR-ScaleOut.changes_12
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_12
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Wed Jul 10 09:23:59 UTC 2024 - abriel@suse.com
+
+- Version bump to 0.185.4
+  * Fix SAPHanaSR-hookHelper by using full pathnames for commands.
+    This will fix the failing fencing with hook susChkSrv.
+    (bsc#1216918)
+  * Fix handling of HANA_CALL timeout return values
+  * update man pages:
+    SAPHanaSR-ScaleOut.7
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR_upgrade_to_angi.7
+    ocf_suse_SAPHanaController.7
+
+-------------------------------------------------------------------
 Tue May  7 16:50:57 UTC 2024 - abriel@suse.com
 
 - Version bump to 0.185.3

--- a/SAPHana/SAPHanaSR-ScaleOut.changes_15
+++ b/SAPHana/SAPHanaSR-ScaleOut.changes_15
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Wed Jul 10 09:23:59 UTC 2024 - abriel@suse.com
+
+- Version bump to 0.185.4
+  * Fix SAPHanaSR-hookHelper by using full pathnames for commands.
+    This will fix the failing fencing with hook susChkSrv.
+    (bsc#1216918)
+  * Fix handling of HANA_CALL timeout return values
+  * update man pages:
+    SAPHanaSR-ScaleOut.7
+    SAPHanaSR_maintenance_examples.7
+    SAPHanaSR_upgrade_to_angi.7
+    ocf_suse_SAPHanaController.7
+
+-------------------------------------------------------------------
 Tue May  7 16:50:57 UTC 2024 - abriel@suse.com
 
 - Version bump to 0.185.3

--- a/SAPHana/test/SAPHanaSR-hookHelper
+++ b/SAPHana/test/SAPHanaSR-hookHelper
@@ -75,7 +75,7 @@ chk_takeover_attr() {
 
 # check, if given SID is configured in the cluster
 sid_is_in_cluster() {
-    csid="$(xmllint -xpath "string(//primitive[@*]/instance_attributes/nvpair[@name='SID' and @value='$RSID']/@value)" "$cibtmp" 2>/dev/null)"
+    csid="$(/usr/bin/xmllint -xpath "string(//primitive[@*]/instance_attributes/nvpair[@name='SID' and @value='$RSID']/@value)" "$cibtmp" 2>/dev/null)"
     if [ -s "$csid" ]; then
         return 1
     else
@@ -87,10 +87,10 @@ sid_is_in_cluster() {
 chk_msres_maintenance() {
     mmaint="false"
     # get multi-state resource name
-    rname=$(xmllint -xpath "string(//master/primitive[@class='ocf' and @provider='suse']/instance_attributes/nvpair[@name='SID' and @value='$RSID']/../../../@id)" "$cibtmp")
+    rname=$(/usr/bin/xmllint -xpath "string(//master/primitive[@class='ocf' and @provider='suse']/instance_attributes/nvpair[@name='SID' and @value='$RSID']/../../../@id)" "$cibtmp")
     if [ -n "$rname" ]; then
         # check for maintenance
-        mmaint=$(xmllint -xpath "string(//master[@id='$rname']/meta_attributes/nvpair[@name='maintenance']/@value)" "$cibtmp")
+        mmaint=$(/usr/bin/xmllint -xpath "string(//master[@id='$rname']/meta_attributes/nvpair[@name='maintenance']/@value)" "$cibtmp")
         if [ -z "$mmaint" ]; then
             mmaint="false"
         fi
@@ -232,9 +232,9 @@ case "$USECASE" in
     fi
     ;;
 "fenceMe" )
-     nodeName=$(crm_node -n)
+     nodeName=$(/usr/sbin/crm_node -n)
      #stonith_admin --reboot="$nodeName"
-     crm --force node fence "$nodeName"
+     /usr/sbin/crm --force node fence "$nodeName"
      rc=42 # if fence is working this rc should never been send back
      ;;
 "firstStopThenKill" )
@@ -244,17 +244,17 @@ case "$USECASE" in
      # this code is for lab only and can be removed without any notice - do not use at customer or partner systems
      # this code does not promise that it will be part of any product later
      #
-     logger -t SAPHanaSR-hookHelper "firstStopThenKill: try to stop SAP instance $InstanceNumber"
+     /usr/bin/logger -t SAPHanaSR-hookHelper "firstStopThenKill: try to stop SAP instance $InstanceNumber"
      stopSystemAndWait "$InstanceNumber" "60"; rc="$?"
      if [ "$rc" -ne 0 ]; then
          # TODO use function for logging
-         logger -t SAPHanaSR-hookHelper "firstStopThenKill: SAP instance $InstanceNumber is not stopped in time - need to kill the instance"
+         /usr/bin/logger -t SAPHanaSR-hookHelper "firstStopThenKill: SAP instance $InstanceNumber is not stopped in time - need to kill the instance"
          HDB kill-9
          # the following logger message will most likely not find the way to the system log, as the SAPHanaSR-hookHelper process will be killed also
-         logger -t SAPHanaSR-hookHelper "firstStopThenKill: SAP instance $InstanceNumber killed with signal 9"
+         /usr/bin/logger -t SAPHanaSR-hookHelper "firstStopThenKill: SAP instance $InstanceNumber killed with signal 9"
      else
          # TODO use function for logging
-         logger -t SAPHanaSR-hookHelper "firstStopThenKill: SAP instance $InstanceNumber is already down - no need to kill the instance"
+         /usr/bin/logger -t SAPHanaSR-hookHelper "firstStopThenKill: SAP instance $InstanceNumber is already down - no need to kill the instance"
      fi
      rc=0
      ;;
@@ -268,13 +268,13 @@ case "$USECASE" in
      stopSystemAndWait "$InstanceNumber" "60"; rc="$?"
      if [ "$rc" -ne 0 ]; then
          # TODO use function for logging
-         logger -t SAPHanaSR-hookHelper "sap instance $InstanceNumber is not stopped in time - need to fence the node"
-         sudo /usr/sbin/SAPHanaSR-hookHelper --sid="$SID" --case="fenceMe"
+         /usr/bin/logger -t SAPHanaSR-hookHelper "sap instance $InstanceNumber is not stopped in time - need to fence the node"
+         /usr/bin/sudo /usr/sbin/SAPHanaSR-hookHelper --sid="$SID" --case="fenceMe"
          # the following logger message will most likely not find the way to the system log, as the node will be already fenced
-         logger -t SAPHanaSR-hookHelper "sap instance $InstanceNumber killed with signal 9"
+         /usr/bin/logger -t SAPHanaSR-hookHelper "sap instance $InstanceNumber killed with signal 9"
      else
          # TODO use function for logging
-         logger -t SAPHanaSR-hookHelper "sap instance $InstanceNumber is already down - no need to fence the node"
+         /usr/bin/logger -t SAPHanaSR-hookHelper "sap instance $InstanceNumber is already down - no need to fence the node"
      fi
      rc=0
      ;;


### PR DESCRIPTION
This will fix the failing fencing with hook susChkSrv too.