### PR TITLE
SAPHanaSR_maintenance_examples.7: typo

### DIFF
--- a/SAPHana/man/SAPHanaSR-ScaleOut.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut.7
@@ -1,6 +1,6 @@
 .\" Version: 0.185.0
 .\"
-.TH SAPHanaSR-ScaleOut 7 "04 Jan 2024" "" "SAPHanaSR"
+.TH SAPHanaSR-ScaleOut 7 "20 Sep 2024" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR-ScaleOut \- Tools for automating SAP HANA system replication in
@@ -342,15 +342,20 @@ Please refer to SAP documentation for details.
 .PP
 27. The Linux user root´s shell is /bin/bash, or completely compatible.
 .PP
+28. No manual actions must be performed on the HANA database while it is controlled
+by the Linux cluster. All administrative actions need to be aligned with the cluster.
+See also SAPHanaSR_maintenance_examples(7).
+.PP
 .\"
 .SH BUGS
-.\" TODO
+.PP
 In case of any problem, please use your favourite SAP support process to open
 a request for the component BC-OP-LNX-SUSE.
 Please report any other feedback and suggestions to feedback@suse.com.
 .PP
 .\"
 .SH SEE ALSO
+.PP
 \fBocf_suse_SAPHanaTopology\fP(7) , \fBocf_suse_SAPHanaController\fP(7) ,
 \fBocf_heartbeat_IPaddr2\fP(7) , \fBSAPHanaSR-ScaleOut_basic_cluster\fP(7) ,
 \fBSAPHanaSR-monitor\fP(8) , \fBSAPHanaSR-showAttr\fP(8) , \fBSAPHanaSR.py\fP(7) ,
@@ -383,7 +388,7 @@ https://blogs.sap.com/2020/01/30/sap-hana-and-persistent-memory/
 .\" TODO SAP notes 3007062 ...
 .PP
 .SH AUTHORS
-.br
+.PP
 A.Briel, F.Herschel, L.Pinne.
 .PP
 .\"

--- a/SAPHana/man/SAPHanaSR_maintenance_examples.7
+++ b/SAPHana/man/SAPHanaSR_maintenance_examples.7
@@ -1,6 +1,6 @@
 .\" Version: 0.160.1
 .\"
-.TH SAPHanaSR_maintenance_examples 7 "27 Mar 2024" "" "SAPHanaSR"
+.TH SAPHanaSR_maintenance_examples 7 "18 Sep 2024" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR_maintenance_examples \- maintenance examples for SAPHana and SAPHanaController.

--- a/SAPHana/man/SAPHanaSR_maintenance_examples.7
+++ b/SAPHana/man/SAPHanaSR_maintenance_examples.7
@@ -185,7 +185,7 @@ If everything looks fine, proceed.
 .br
 ~> HDBsettings.sh systemReplicationStatus.py; echo RC:$?
 .br
-~> HDBsettings.sh landscapeConfigurationStatus.py; echo RC:$?
+~> HDBsettings.sh landscapeHostConfiguration.py; echo RC:$?
 .br
 ~> exit
 .br

--- a/SAPHana/man/SAPHanaSR_maintenance_examples.7
+++ b/SAPHana/man/SAPHanaSR_maintenance_examples.7
@@ -1,6 +1,6 @@
 .\" Version: 0.160.1
 .\"
-.TH SAPHanaSR_maintenance_examples 7 "18 Sep 2024" "" "SAPHanaSR"
+.TH SAPHanaSR_maintenance_examples 7 "20 Sep 2024" "" "SAPHanaSR"
 .\"
 .SH NAME
 SAPHanaSR_maintenance_examples \- maintenance examples for SAPHana and SAPHanaController.
@@ -19,7 +19,7 @@ below.
 .SH EXAMPLES
 .PP
 \fB*\fR Check status of Linux cluster and HANA system replication pair.
-
+.PP
 This steps should be performed before doing anything with the cluster, and
 after something has been done. See also cs_show_saphanasr_status(8) and section
 REQUIREMENTS below.
@@ -37,7 +37,7 @@ REQUIREMENTS below.
 .RE
 .PP
 \fB*\fR Watch status of HANA cluster resources and system replication.
-
+.PP
 This might be convenient when performing administrative actions or cluster tests. It does not replace the afore mentioned checks. See also cs_show_saphanasr_status(8).
 .PP
 .RS 4
@@ -45,7 +45,7 @@ This might be convenient when performing administrative actions or cluster tests
 .RE
 .PP
 \fB*\fR Overview on stopping the HANA database at one site.
-
+.PP
 This procedure does work for scale-up and scale-out. No takeover will be done. This procedure
 should be used, when it is necessary to stop the HANA database. Stopping the HANA database
 should not be done by just stopping the Linux cluster or shutting down the OS. This particularly
@@ -70,7 +70,7 @@ tuning and stopping an HANA database.
 Note: Do not forget to end the resource maintenance after you have re-started the HANA database.
 .PP
 \fB*\fR Initiate an administrative takeover of the HANA primary from one node to the other by using the Linux cluster. 
-
+.PP
 This procedure does not work for scale-out. On scale-up, it will stop the HANA primary.
 This might take a while. If you want to avoid waiting for the stopped primary,
 use the below procedure which suspends the primary.
@@ -105,7 +105,7 @@ After takeover of the primary has been finished, the migration rule has to be de
 Note: Former versions of the Linux cluster used "migrate" instead of "move" and "unmigrate" instead of "clear".
 .PP
 \fB*\fR Perform an SAP HANA takeover by using SAP tools. 
-
+.PP
 The procedure is described here for scale-out. It works for scale-up as well. 
 The procedure will stop the HANA primary. This might take a while. If you want
 to avoid waiting for the stopped primary, use the below procedure which suspends
@@ -210,7 +210,7 @@ If everything looks fine, proceed.
 .RE
 .PP
 \fB*\fR Overview on SAP HANA takeover using SAP tools and suspend primary feature.
-
+.PP
 The procedure works for scale-up and scale-out.
 The status of HANA databases, system replication and Linux cluster has to be
 checked.
@@ -249,7 +249,7 @@ See also section REQUIREMENTS below and later example on determining the correct
 .RE
 .PP
 \fB*\fR Check the two site names that are known to the Linux cluster. 
-
+.PP
 This is useful in case AUTOMATED_REGISTER is not yet set. In that case a former  primary needs to be registered manually with the former site name as new secondary. The point is finding the site name that already is in use by the Linux cluster. That exact site name has to be used for registration of the new secondary. See also REQUIREMENTS of SAPHanaSR(7) and SAPHanaSR-ScaleOut(7).
 .br
 In this example, node is suse11 on the future secondary site to be registered. Remote HANA master nameserver is suse21 on current primary site. Lowercase-SID is ha1.
@@ -267,7 +267,7 @@ In this example, node is suse11 on the future secondary site to be registered. R
 .RE
 .PP
 \fB*\fR Manually start the HANA primary if only one site is available.
-
+.PP
 This might be necessary in case the cluster can not detect the status of both sites.
 This is an advanced task.
 .PP
@@ -295,9 +295,8 @@ This is an advanced task.
 10. Please bring back the other node and register that HANA as soon as possible. If the HANA primary stays alone for too long, the log area will fill up.
 .RE
 .PP
-.\"
 \fB*\fR Overview on maintenance procedure for HANA, the Linux cluster remains running, on pacemaker 1.0.
-
+.PP
 See also section REQUIREMENTS below.
 .PP
 .RS 2
@@ -381,7 +380,7 @@ been used, left-over maintenance attribute have to be removed from the CIB
 before proceeding with the new procedure for pacemaker-2.0.
 .PP
 \fB*\fR Overview on maintenance procedure for Linux, HANA remains running, on pacemaker-2.0.
-
+.PP
 It is necessary to wait for each step to complete and to check the result. It
 also is necessary to test and document the whole procedure before applying in production.
 See also section REQUIREMENTS below and example on checking status of HANA and cluster above.
@@ -439,7 +438,7 @@ See also section REQUIREMENTS below and example on checking status of HANA and c
 .PP
 \fB*\fR Overview on simple procedure for stopping and temporarily disabling the Linux cluster,
 HANA gets fully stopped.
-
+.PP
 This procedure can be used to update HANA, OS or hardware.
 HANA roles and resource status remains unchanged.
 It is necessary to wait for each step to complete and to check the result.
@@ -476,12 +475,12 @@ It also is necessary to test and document the whole procedure before applying in
 .br
 - system replication recovers to SOK
 .RE
-
+.PP
 Note: HANA is not available from step 4 to step 9. 
 .RE
 .PP
 \fB*\fR Overview on update procedure for the SAPHanaSR and SAPHanaSR-ScaleOut package.
-
+.PP
 This procedure can be used to update RAs, HANA HADR provider hook scripts and related tools while HANA and Linux cluster stay online. See also SAPHanaSR-manageAttr(8) for details on reloading the HANA HADR provider.
 .PP
 .RS 2
@@ -501,7 +500,7 @@ This procedure can be used to update RAs, HANA HADR provider hook scripts and re
 .RE
 .PP
 \fB*\fR Remove left-over maintenance attribute from overall Linux cluster.
-
+.PP
 This could be done to avoid confusion caused by different maintenance procedures.
 See above overview on maintenance procedures with running Linux cluster.
 Before doing so, check for cluster attribute maintenance-mode="false".
@@ -517,7 +516,7 @@ Before doing so, check for cluster attribute maintenance-mode="false".
 .RE
 .PP
 \fB*\fR Remove left-over standby attribute from Linux cluster nodes.
-
+.PP
 This could be done to avoid confusion caused by different maintenance procedures.
 See above overview on maintenance procedures with running Linux cluster.
 Before doing so for all nodes, check for node attribute standby="off" on all nodes.
@@ -533,7 +532,7 @@ Before doing so for all nodes, check for node attribute standby="off" on all nod
 .RE
 .PP
 \fB*\fR Remove left-over maintenance attribute from resource.
-
+.PP
 This should usually not be needed.
 See above overview on maintenance procedures with running Linux cluster.
 .PP
@@ -546,7 +545,7 @@ See above overview on maintenance procedures with running Linux cluster.
 .RE
 .PP
 \fB*\fR Manually update global site attribute.
-
+.PP
 In rare cases the global site attribute hana_<sid>_glob_prim or
 hana_<sid>_glob_sec is not updated automatically after successful takeover,
 while all other attributes are updated correctly. The global site attribute
@@ -564,7 +563,7 @@ been updated. Updating hana_<sid>_glob_sec for SID HA1 with site name VOLKACH:
 .RE
 .PP
 \fB*\fR Upgrade scale-out srHook attribute from old-style to multi-target.
-
+.PP
 As final result of this upgrade, the RAs and hook script are upgraded from
 old-style to multi-target. Further the Linux cluster's old-style global srHook
 attribute hana_${sid}_glob_srHook is replaced by site-aware attributes
@@ -602,11 +601,10 @@ l. Finally check if everything looks fine.
 .PP
 .\"
 .SH FILES
-.br
 .PP
 .\"
 .SH REQUIREMENTS
-.br
+.PP
 \fB*\fR For the current version of the resource agents that come with the software packages SAPHanaSR and SAPHanaSR-ScaleOut, the support is limited to the scenarios and parameters described in the respective manual pages SAPHanaSR(7) and SAPHanaSR-ScaleOut(7).
 .PP
 \fB*\fR Be patient. For detecting the overall HANA status, the Linux cluster
@@ -628,17 +626,21 @@ outside the cluster creates risk of a duplicate-primary situation. The user is
 responsible for data integrity, particularly when activating an HANA primary. See
 also susTkOver.py(7).
 .PP
+\fB*\fR When manually disabling or unregistering HANA system replication that is
+controlled by the Linux cluster, the SAPHanaController resource needs to be in
+maintenance mode. The user is responsible for data integrity.
+.PP
 \fB*\fR HANA site names are discovered automatically when the RAs are activated the
 very first time. That exact site names have to be used later for all manual tasks.
 .PP
 .\"
 .SH BUGS
-.\" TODO
+.PP
 In case of any problem, please use your favourite SAP support process to open a request for the component BC-OP-LNX-SUSE. Please report any other feedback and suggestions to feedback@suse.com.
 .PP
 .\"
 .SH SEE ALSO
-.br
+.PP
 \fBocf_suse_SAPHanaTopology\fP(7) , \fBocf_suse_SAPHana\fP(7) ,
 \fBocf_suse_SAPHanaController\fP(7) ,
 \fBSAPHanaSR.py\fP(7) , \fBSAPHanaSrMultiTarget.py\fP(7) ,
@@ -667,7 +669,7 @@ https://help.sap.com/doc/eb75509ab0fd1014a2c6ba9b6d252832/1.0.12/en-US/SAP_HANA_
 .PP
 .\"
 .SH AUTHORS
-.br
+.PP
 F.Herschel, L.Pinne.
 .PP
 .\"


### PR DESCRIPTION
Hi,
typo in man page SAPHanaSR_maintenance_examples.7 fixed.
Regards,
Lars