### PR TITLE
#1259178: SAPHanaSR-manageAttr should accept "maintenance" as well as "unmanaged"

### DIFF
--- a/SAPHana/bin/SAPHanaSR-manageAttr
+++ b/SAPHana/bin/SAPHanaSR-manageAttr
@@ -99,7 +99,7 @@ get_hana_attribute() {
 }
 
 # call the RA to initialize the needed attributes.
-# should be called only, if cluster or the resources are in mainteance/unmanaged
+# should be called only, if cluster or the resources are in maintenance/unmanaged
 init_ra() {
     if [ -z "$INO" ]; then
         raEnv="export OCF_ROOT=${OCFROOT}; export OCF_RESKEY_SID=${RSID}"
@@ -904,7 +904,7 @@ chk_for_maintenance() {
             cmaint="false"
     fi
     for m in $resM; do
-        if ! crm_mon -r1 | grep "$m" | grep unmanaged >/dev/null 2>&1; then
+        if ! crm_mon -r1 | grep "$m" | grep -e unmanaged -e maintenance >/dev/null 2>&1; then
             mmaint="false"
         fi
     done
@@ -912,7 +912,7 @@ chk_for_maintenance() {
         mslInMaint="true"
     fi
     for c in $resC; do
-        if ! crm_mon -r1 | grep "$c" | grep unmanaged >/dev/null 2>&1; then
+        if ! crm_mon -r1 | grep "$c" | grep -e unmanaged -e maintenance >/dev/null 2>&1; then
             cmaint="false"
         fi
     done

--- a/SAPHana/man/SAPHanaSR_upgrade_to_angi.7
+++ b/SAPHana/man/SAPHanaSR_upgrade_to_angi.7
@@ -625,7 +625,7 @@ A.Briel, F.Herschel, L.Pinne.
 .\"
 .SH COPYRIGHT
 .\"
-(c) 2024 SUSE LLC
+(c) 2024-2026 SUSE LLC
 .br
 This maintenance examples are coming with ABSOLUTELY NO WARRANTY.
 .br


### PR DESCRIPTION
Hi,
in recent 15sp6 and 15sp7 resource status now is reported as "maintenance" instead of "unmanaged".  See #1259178. 
Regards,
Lars 