### PR TITLE
SAPHanaSR-manageAttr: fix crm cluster run output parsing

### DIFF
--- a/SAPHana/bin/SAPHanaSR-manageAttr
+++ b/SAPHana/bin/SAPHanaSR-manageAttr
@@ -444,9 +444,9 @@ get_global_ini_hooks() {
     local section=""
 
     GLOBINI=$(mktemp /tmp/saphana-manageAttr.XXXXXXXX)
-    $runCmd "cat $globalIni" 2>&1 | awk -v tmpf="$GLOBINI" '
+    $runCmd "cat $globalIni" 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | awk -v tmpf="$GLOBINI" '
         BEGIN {list = 0}
-        /OK: \[/ || /ERROR: \[/ {
+        /OK: \[/ || /ERROR: \[/ || /INFO: \[/ {
             if (siteID == "") { next }
             if (siteID in site) {
                 # skip last data


### PR DESCRIPTION
In recent crmsh versions (crmsh-4.5.0+20230725 and later, SLES 15 SP5+), the output format of crm cluster run changed from OK: [node] to INFO: [node], also passing color-related sepecial escape codes into pipes (not just TTY). This breaks the awk parser in get_global_ini_hooks(). See bsc#1259178